### PR TITLE
Add pages array to sample.blog.json

### DIFF
--- a/sample.blog.json
+++ b/sample.blog.json
@@ -19,5 +19,15 @@
       "title": "Reptiles run the world",
       "source": "https://gist.githubusercontent.com/thomasdavis/03b712d36272c9e79535c583bf8e70b8/raw/1aa2f00e62ac85d1f51d0792facb1af8db4b6ef3/second.md"
     }
+  ],
+  "pages": [
+    {
+      "title": "About",
+      "source": "https://gist.githubusercontent.com/thomasdavis/7451150385ee571e4ef87ffcefabc583/raw/about.md"
+    },
+    {
+      "title": "Contact",
+      "source": "https://gist.githubusercontent.com/thomasdavis/855f6d9869236b89de4a87a636ab3ac2/raw/contact.md"
+    }
   ]
 }


### PR DESCRIPTION
This will solve issues in other libraries that depend on `sample.json.blog` containing a `pages` array.

Allowing `pages` to be optional as PR'd here: https://github.com/jsonblog/jsonblog-generator-boilerplate/pull/9 is an alternative.